### PR TITLE
fix minor bugs due to API change of Web Learning

### DIFF
--- a/thulearn2018/jsonhelper.py
+++ b/thulearn2018/jsonhelper.py
@@ -1,20 +1,16 @@
 import json
-import platform
+from re import findall
 
 class JsonHelper():
     def __init__(self):
         pass
 
     def loads(self, content):
-        def is_windows():
-            return platform.system() == 'Windows'
-            
         result = {}
         try:
-            if(is_windows()):
-                result = json.loads(bytes.decode(content))
-            else:
-                result = json.loads(content)
+            if isinstance(content, bytes):
+                content = bytes.decode(content)
+            result = json.loads(findall(r'({.*})', content)[0])
         except Exception:
             print("密码错误")
             exit(1)

--- a/thulearn2018/settings.py
+++ b/thulearn2018/settings.py
@@ -30,7 +30,7 @@ def file_url(lesson_id, file_id):
     return url + "b/wlxt/kj/wlkc_kjxxb/student/kjxxb/" + lesson_id + "/" + file_id
 
 def lessons_url(semester):
-    return url + "/b/wlxt/kc/v_wlkc_xs_xkb_kcb_extend/student/loadCourseBySemesterId/" + semester
+    return url + "b/wlxt/kc/v_wlkc_xs_xkb_kcb_extend/student/loadCourseBySemesterId/" + semester + "/en"
 
 def download_before_url(fid):
     return url + "b/kc/wj_wjb/downloadFileBefore?wjid=" + fid


### PR DESCRIPTION
In 2023, 2 minor changes of Web Learning has stopped the previous version from working:

1. Instead of returning json only, `self.post(settings.lessons_url(self.semester))` now returns a mixture of json and html, so a regex has to be added.
2. An extra option `zh` or `en` was added to the path `https://learn.tsinghua.edu.cn/b/wlxt/kc/v_wlkc_xs_xkb_kcb_extend/student/loadCourseBySemesterId/<semesterId>/` to enable multilanguage support, so the request has to be updated accordingly.

Fixed but only tested on GNU/Linux. Suggestions welcomed.